### PR TITLE
fix_children_addenda_users_other_parties_variables

### DIFF
--- a/docassemble/MLHDivorceAndCustody/data/questions/documents.yml
+++ b/docassemble/MLHDivorceAndCustody/data/questions/documents.yml
@@ -1565,7 +1565,7 @@ attachment:
           ${ plaintiffs[0].job.employer.name.first }
           ${ plaintiffs[0].job.employer.address.line_one() }
           ${ plaintiffs[0].job.employer.address.line_two() }
-          ${ word("Phone unknown.") if plaintiffs[0].job.employer.phone == "" else users[0].job.employer.phone }
+          ${ word("Phone unknown.") if plaintiffs[0].job.employer.phone == "" else plaintiffs[0].job.employer.phone }
           % endif
       - defendant_employer_block: |
           % if defendants[0].has_job:


### PR DESCRIPTION
Fix/revert non-judgment/children addenda variables back to users[0] and other_parties[0] where appropriate instead of plaintiffs and defendants