### PR TITLE
Fix lists

### DIFF
--- a/docassemble/MLHDivorceAndCustody/data/questions/question_bank.yml
+++ b/docassemble/MLHDivorceAndCustody/data/questions/question_bank.yml
@@ -1732,7 +1732,6 @@ fields:
     datatype: yesnoradio
 ---
 id: marriage.debts.pay_debts_in_own_names
-if: marriage.debts.any
 question: |
   ${marriage.debts.question_text}
 fields:
@@ -1747,7 +1746,6 @@ fields:
       is: False
 ---
 id: marriage.debts.any_in_both_names
-if: marriage.debts.any
 question: |
   ${marriage.debts.question_text}
 fields:

--- a/docassemble/MLHDivorceAndCustody/data/questions/review.yml
+++ b/docassemble/MLHDivorceAndCustody/data/questions/review.yml
@@ -899,12 +899,12 @@ review:
 #    show if: marriage.debts.attribute_defined("any")
   - Edit:
       - invalidate:
+        - marriage.debts.any
         - marriage.debts.pay_debts_in_own_names
         - marriage.debts.agree_responsibility_debts_own_name
         - marriage.debts.any_in_both_names
         - marriage.debts.agree_responsibility_debts_both_names
       - marriage.debts.info
-      - marriage.debts.any
       - recompute:
         - marriage.debts.need_items
       - follow up:


### PR DESCRIPTION
This PR is to fix the issues brought up in the Slack thread that is screenshotted below.

The root of the issue is that when you're in a `force_ask` event due to the review screen edit, you can't edit the list items, "Input not processed". The workaround I did here is to gather the lists as empty from the interview flow if the items aren't needed. Then if they edit, the `revisit` screens are shown where the user can add and edit items, rather than going back through the "interview" flow and trying to `gather()` again.

There are some caveats with these changes:

- The user loses the yes/no radio buttons on edits. I cannot come up with an alternative that works and retains them, since there's no way to use the `yesnoradio` with the `add_action` that is required on the `revisit` screen.
- I made it so that if the user gets onto the debt list page, they have to enter at least one debt (if they get there through the interview flow they'll have had to enter one debt already, if they get there via the edit flow they'll have to enter one or they'll get a validation error saying so).
- It is possible to say that you have personal property that needs to be handled and then skip adding any (this was possible before as well).
- I put all of the questions onto one page for each of the sections so that I could handle the "need_items" determinations with validation code because I could not get `depends on` or `on change` to work consistently.
- I clear the list if the user edits their answer to the section questions in a way that would cause them to not need to provide those items. This is different than before where I would just leave the list un-gathered. This is probably safer in terms of the documents not triggering list gathering, but potentially worse if the user adds a bunch of items, edits the question clearing the list, and then later decides that they did actually have items they wanted, since they will have to re-enter those items.

I also re-arranged `vehicles` in the review screen to match the interview flow.

---

![Picsew_20251216174955](https://github.com/user-attachments/assets/a22cf373-8fb7-4ec6-af6f-247f9e59e633)
